### PR TITLE
Interval Selection Fix

### DIFF
--- a/km.ci/R/epband.fun.R
+++ b/km.ci/R/epband.fun.R
@@ -20,8 +20,21 @@ function(survi, tl=NA,tu=NA, method="linear",conf.lev=0.95)
     # if no tl,tu is given the band covers the whole curve
     if(is.na(tl)&is.na(tu))
     {
-        tl <- min(survi$time[survi$n.event>0])
-        tu <- max(survi$time[survi$n.event>0 &survi$n.risk>survi$n.event])
+      ##Proposed fix for interval selection
+      n <- survi$n
+      time <- survi$time
+      kap.mei <- survi$surv
+      n.risk <- survi$n.risk
+      n.event <- survi$n.event
+      a <- n.event/(n.risk*(n.risk-n.event))
+      a <- cumsum(a)
+      var.st <- kap.mei^2*a    
+      sigma <- var.st/kap.mei^2
+      K <- n*sigma/(1+n*sigma)
+      
+      beta <- min(1-alpha,max(K[n.event>0 &n.risk>n.event]))
+      tl <- time[min(which(K >= alpha))]
+      tu <- time[max(which(K <= beta))]
     }
     n <- survi$n
     aa <- a.up.low.fun(survi,tl,tu)

--- a/km.ci/R/epband.fun.R
+++ b/km.ci/R/epband.fun.R
@@ -1,5 +1,5 @@
 "epband.fun" <-
-function(survi, tl=NA,tu=NA, method="linear",conf.lev=0.95)
+function(survi, tl=NA,tu=NA,alpha=0.05, method="linear",conf.lev=0.95)
 {
     # This function takes a survfit object and modifies it, such that
     # its lower and upper boundaries are now computed using the

--- a/km.ci/R/km.ci.R
+++ b/km.ci/R/km.ci.R
@@ -1,5 +1,5 @@
 "km.ci" <-
-function(survi,conf.level=0.95, tl=NA, tu=NA, method="rothman")
+function(survi,conf.level=0.95, tl=NA, tu=NA, alpha=0.05, method="rothman")
 {
     # This function can compute the most desirable confidence bands.
     # The method "log" is implemented as "log" in R survfit.
@@ -70,12 +70,12 @@ function(survi,conf.level=0.95, tl=NA, tu=NA, method="rothman")
 
     if(method=="epband")
     {
-        result <- epband.fun(survi, tl=tl, tu=tu, conf.lev=conf.level)
+        result <- epband.fun(survi, tl=tl, tu=tu, alpha=alpha, conf.lev=conf.level)
         result$conf.type <- "Equal Precision"
     }
     if(method=="logep")
     {
-        result <- epband.fun(survi, tl=tl, tu=tu, method="log",conf.lev=conf.level)
+        result <- epband.fun(survi, tl=tl, tu=tu, alpha=alpha, method="log",conf.lev=conf.level)
         result$conf.type <- "Log(Equal Precision)"
     }
     return(result)


### PR DESCRIPTION
Fix of the interval selection by the method proposed by Nair on page 266
of his 1984 paper 'Confidence Bands for Survival Functions with Censored
Data: A Comparative Study'.
